### PR TITLE
fix: resolve TypeScript 5.9 build errors

### DIFF
--- a/bd/api/index.ts
+++ b/bd/api/index.ts
@@ -57,7 +57,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 
-app.use(compression());
+app.use(compression() as any);
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 

--- a/bd/src/controllers/admin.controller.ts
+++ b/bd/src/controllers/admin.controller.ts
@@ -38,7 +38,7 @@ export const getDashboardStats = async (req: Request, res: Response): Promise<vo
             count: { $sum: 1 },
           },
         },
-      ]).maxTimeMS(5000),
+      ]).option({ maxTimeMS: 5000 }),
     ]);
 
     const stats = revenueResult[0] || { revenue: 0, count: 0 };

--- a/bd/src/server.ts
+++ b/bd/src/server.ts
@@ -59,7 +59,7 @@ app.use(cors(corsOptions));
 // Ensure OPTIONS requests are handled
 app.options('*', cors(corsOptions));
 
-app.use(compression());
+app.use(compression() as any);
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 


### PR DESCRIPTION
- Cast compression() middleware to fix @types/compression Express type conflict
- Replace .maxTimeMS() with .option({ maxTimeMS }) for Mongoose 8 compatibility